### PR TITLE
Slightly reduce gas consumption for deposit

### DIFF
--- a/contracts/EasyStaking.sol
+++ b/contracts/EasyStaking.sol
@@ -125,8 +125,8 @@ contract EasyStaking is Ownable {
      * @param _amount The amount to deposit.
      */
     function deposit(uint256 _amount) public {
-        lastDepositIds[msg.sender] += 1;
-        uint256 id = lastDepositIds[msg.sender];
+        uint256 id = lastDepositIds[msg.sender] + 1;
+        lastDepositIds[msg.sender] = id;
         deposit(id, _amount);
     }
 

--- a/contracts/EasyStaking.sol
+++ b/contracts/EasyStaking.sol
@@ -160,8 +160,8 @@ contract EasyStaking is Ownable {
     function onTokenTransfer(address _sender, uint256 _amount, bytes calldata) external {
         require(msg.sender == address(token), "only token contract is allowed");
         if (!locked) {
-            lastDepositIds[_sender] += 1;
-            uint256 id = lastDepositIds[_sender];
+            uint256 id = lastDepositIds[_sender] + 1;
+            lastDepositIds[_sender] = id;
             _deposit(_sender, id, _amount);
         }
     }


### PR DESCRIPTION
Not sure, but this should reduce gas consumption by 800 (one SLOAD operation instead of two) for both `deposit` and `onTokenTransfer` functions.